### PR TITLE
Use CXX implicit variable

### DIFF
--- a/spike/native/makefile
+++ b/spike/native/makefile
@@ -19,9 +19,9 @@ CFLAGS+= -Wextra -Wno-unused-parameter -Wno-ignored-qualifiers
 default: all
 
 all:
-	g++ -c $(CFLAGS) -D MFM_BUILD_DATE=1 -D MFM_BUILD_TIME=2 -I include -I $(MFM_INCLUDES) -I $(MFM_PLATFORM_INCL) ./src/*.cpp
+	$(CXX) -c $(CFLAGS) -D MFM_BUILD_DATE=1 -D MFM_BUILD_TIME=2 -I include -I $(MFM_INCLUDES) -I $(MFM_PLATFORM_INCL) ./src/*.cpp
 # mfmcore intentionally linked twice
-	g++ -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_SIM) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmsim -l mfmplatform-linux -l mfmcore -pthread -o main
+	$(CXX) -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_SIM) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmsim -l mfmplatform-linux -l mfmcore -pthread -o main
 #	valgrind ./main
 
 clean: 	FORCE

--- a/spike/native/makefile-perf
+++ b/spike/native/makefile-perf
@@ -25,9 +25,9 @@ CFLAGS+= -Wextra -Wno-unused-parameter -Wno-ignored-qualifiers
 default: all
 
 all:
-	g++ -c $(CFLAGS) -D MFM_BUILD_DATE=1 -D MFM_BUILD_TIME=2 -I include -I $(MFM_INCLUDES) -I $(MFM_PLATFORM_INCL) ./src/*.cpp
+	$(CXX) -c $(CFLAGS) -D MFM_BUILD_DATE=1 -D MFM_BUILD_TIME=2 -I include -I $(MFM_INCLUDES) -I $(MFM_PLATFORM_INCL) ./src/*.cpp
 # mfmcore intentionally linked twice
-	g++ $(LFLAGS) -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_SIM) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmsim -l mfmplatform-linux -l mfmcore -pthread -o main
+	$(CXX) $(LFLAGS) -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_SIM) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmsim -l mfmplatform-linux -l mfmcore -pthread -o main
 #	valgrind ./main
 
 clean: 	FORCE

--- a/spike/quick_foo/bitsize_test/Makefile
+++ b/spike/quick_foo/bitsize_test/Makefile
@@ -8,8 +8,8 @@ CFLAGS:= -g -pthread -Wall -ansi -pedantic -Werror
 default: all
 
 all:	FORCE
-	g++ -c $(CFLAGS) -I ../../../include -I $(MFM_INCLUDES) *.cpp
-	g++ -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmplatform-linux -l mfmcore -pthread -o main
+	$(CXX) -c $(CFLAGS) -I ../../../include -I $(MFM_INCLUDES) *.cpp
+	$(CXX) -L $(MFM_BUILD_CORE) -L $(MFM_BUILD_PLATFORM) ./*.o -l mfmcore -l mfmplatform-linux -l mfmcore -pthread -o main
 
 clean:
 	rm -f *.o

--- a/spike/spike12/Makefile
+++ b/spike/spike12/Makefile
@@ -25,10 +25,10 @@ $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
 $(BIN_DIR)/%: $(BUILD_DIR)/%.o  | $(BIN_DIR)
-	g++ $< $(ULAMLIB) -o $@
+	$(CXX) $< $(ULAMLIB) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c $(CFLAGS) $(INCLUDES) $< -o $@
+	$(CXX) -c $(CFLAGS) $(INCLUDES) $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/spike/spike13/Makefile
+++ b/spike/spike13/Makefile
@@ -23,10 +23,10 @@ $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
 $(BIN_DIR)/%: $(BUILD_DIR)/%.o  | $(BIN_DIR)
-	g++ $< $(ULAMLIB) -o $@
+	$(CXX) $< $(ULAMLIB) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c $(CFLAGS) $(INCLUDES) $< -o $@
+	$(CXX) -c $(CFLAGS) $(INCLUDES) $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/spike/spike14/Makefile
+++ b/spike/spike14/Makefile
@@ -23,10 +23,10 @@ $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
 $(BIN_DIR)/%: $(BUILD_DIR)/%.o  | $(BIN_DIR)
-	g++ $< $(ULAMLIB) -o $@
+	$(CXX) $< $(ULAMLIB) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c $(CFLAGS) $(INCLUDES) $< -o $@
+	$(CXX) -c $(CFLAGS) $(INCLUDES) $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/drivers/culam/Makefile
+++ b/src/drivers/culam/Makefile
@@ -18,10 +18,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BIN_DIR)/$(DRIVER_NAME): ${OBJS} | $(BIN_DIR)
-	g++ $(OBJS) $(LIBS) -o $@
+	$(CXX) $(OBJS) $(LIBS) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/drivers/eulam/Makefile
+++ b/src/drivers/eulam/Makefile
@@ -19,10 +19,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BIN_DIR)/$(DRIVER_NAME): ${OBJS} | $(BIN_DIR)
-	g++ $(OBJS) $(LIBS) -o $@
+	$(CXX) $(OBJS) $(LIBS) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/drivers/gtest/Makefile
+++ b/src/drivers/gtest/Makefile
@@ -22,10 +22,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BIN_DIR)/$(DRIVER_NAME): ${OBJS} | $(BIN_DIR)
-	g++ $(OBJS) $(LIBS) -o $@
+	$(CXX) $(OBJS) $(LIBS) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/drivers/ptest/Makefile
+++ b/src/drivers/ptest/Makefile
@@ -22,10 +22,10 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BIN_DIR)/$(DRIVER_NAME): ${OBJS} | $(BIN_DIR)
-	g++ $(OBJS) $(LIBS) -o $@
+	$(CXX) $(OBJS) $(LIBS) -o $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/drivers/test/Makefile
+++ b/src/drivers/test/Makefile
@@ -21,11 +21,11 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BIN_DIR)/$(DRIVER_NAME): ${OBJS} | $(BIN_DIR)
-	g++ $(OBJS) $(LIBS) -o $@
+	$(CXX) $(OBJS) $(LIBS) -o $@
 ##	$(BIN_DIR)/test
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -27,7 +27,7 @@ $(BUILD_DIR)/libtests.a: $(OBJS)
 	@echo '$(TESTS)' > $(BUILD_DIR)/tests.inc
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c $(CFLAGS) ${DEFINES} $(INCLUDES) $< -o $@
+	$(CXX) -c $(CFLAGS) ${DEFINES} $(INCLUDES) $< -o $@
 
 gen: $(TGEN_DIR)
 #	cp $(SHARE_DIR)/tcc/*.tcc $(TGEN_DIR)/include/.

--- a/src/test/generic/Makefile
+++ b/src/test/generic/Makefile
@@ -27,7 +27,7 @@ $(BUILD_DIR)/libtests.a: $(OBJS)
 	@echo '$(TESTS)' > $(BUILD_DIR)/tests.inc
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c $(CFLAGS) ${DEFINES} $(INCLUDES) $< -o $@
+	$(CXX) -c $(CFLAGS) ${DEFINES} $(INCLUDES) $< -o $@
 
 gen: FORCE
 #	cp $(SHARE_DIR)/tcc/*.tcc $(TGEN_DIR)/include/.

--- a/src/ulam/Makefile
+++ b/src/ulam/Makefile
@@ -19,7 +19,7 @@ $(BUILD_DIR)/libulam.a: ${OBJS}
 	ranlib $@
 
 $(BUILD_DIR)/%.o: %.cpp $(HDRS) $(INCS) $(ALLDEP) | $(BUILD_DIR)
-	g++ -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
+	$(CXX) -c ${CFLAGS} ${DEFINES} ${INCLUDES} $< -o $@
 
 clean:	FORCE
 	@rm -f *~


### PR DESCRIPTION
Variable to call g++ by another name (i.e. g++-4.9). GNU make supports the implicit variable CXX that defaults to g++. 