### PR TITLE
Re-running partial instantiation for recursive typedef stub classes a…

### DIFF
--- a/include/CompilerState.h
+++ b/include/CompilerState.h
@@ -449,6 +449,7 @@ namespace MFM{
     bool checkAndLabelPassForLocals();
     bool checkforAnyRemainingCulamGeneratedTypedefsInThisContext(UTI thisarg);
     u32 findNameIdOfCulamGeneratedTypedefTypeInThisContext(UTI typearg);
+    bool checkForAnyIncompleteTemplateClassInstances(UTI thisarg);
 
     u32 getClassIdBits();
     u32 getMaxNumberOfRegisteredUlamClasses();

--- a/include/SymbolClass.h
+++ b/include/SymbolClass.h
@@ -223,6 +223,8 @@ namespace MFM{
     bool isStubForTemplate();
     UTI getStubForTemplateType();
     void setStubForTemplateType(UTI ttype);
+    bool isStubForTemplateTypeIncomplete();
+    void setStubForTemplateTypeIncomplete(bool incomplete);
     void clearStubForTemplate();
 
   protected:
@@ -238,6 +240,7 @@ namespace MFM{
     bool m_stubcopy;
     bool m_stubForTemplate; //ulam-5 (t41440, t41224)
     UTI m_stubForTemplateType;
+    bool m_stubForTemplateTypeIncomplete;
     UTI m_stubcopyOf;
     bool m_stubcopyfromseentemplatestub;
     BV8K m_defaultValue; //BitVector

--- a/include/SymbolClassNameTemplate.h
+++ b/include/SymbolClassNameTemplate.h
@@ -82,6 +82,8 @@ namespace MFM{
     void fixAnyUnseenClassInstances();
     void fixAClassStubsDefaultArgs(SymbolClass * stubcsym, u32 defaultstartidx);
 
+    void fixAnyIncompleteClassInstances();
+
     bool statusNonreadyClassArgumentsInStubClassInstances();
 
     virtual std::string formatAnInstancesArgValuesAsAString(UTI instance, bool dereftypes = false);

--- a/src/ulam/CompilerState.cpp
+++ b/src/ulam/CompilerState.cpp
@@ -4038,6 +4038,18 @@ namespace MFM {
     return rtnid;
   } //findNameIdOfCulamGeneratedTypedefTypeInThisContext (unused)
 
+  bool CompilerState::checkForAnyIncompleteTemplateClassInstances(UTI thisarg) {
+    assert(isClassATemplate(thisarg));
+
+    SymbolClassNameTemplate * cnsym = NULL;
+    AssertBool isDefined = alreadyDefinedSymbolClassNameTemplateByUTI(thisarg, cnsym);
+    assert(isDefined);
+
+    cnsym->fixAnyIncompleteClassInstances();
+
+    return false;
+  } // checkForAnyIncompleteTemplateClassInstances
+
   u32 CompilerState::getClassIdBits()
   {
     //initialized to constant CLASSIDBITS

--- a/src/ulam/Parser.cpp
+++ b/src/ulam/Parser.cpp
@@ -481,8 +481,11 @@ namespace MFM {
 	delete rtnNode;
 	rtnNode = NULL;
       }
-    else
+    else {
       m_state.checkforAnyRemainingCulamGeneratedTypedefsInThisContext(cnsym->getUlamTypeIdx()); //t3347,t3544, ulamexports
+      if (cnsym->isClassTemplate())
+        m_state.checkForAnyIncompleteTemplateClassInstances(cnsym->getUlamTypeIdx());
+    }
 
     //this block's ST is no longer in scope
     m_state.popClassContext(); //m_currentBlock = prevBlock;

--- a/src/ulam/SymbolClass.cpp
+++ b/src/ulam/SymbolClass.cpp
@@ -11,11 +11,11 @@
 
 namespace MFM {
 
-  SymbolClass::SymbolClass(const Token& id, UTI utype, NodeBlockClass * classblock, SymbolClassNameTemplate * parent, CompilerState& state) : Symbol(id, utype, state), m_resolver(NULL), m_classBlock(classblock), m_parentTemplate(parent), m_quarkunion(false), m_stub(true), m_stubcopy(false), m_stubForTemplate(false), m_stubForTemplateType(Nouti), m_stubcopyOf(Nouti), /*m_defaultValue(NULL),*/ m_isreadyDefaultValue(false) /* default */, m_bitsPacked(false), m_registryNumber(UNINITTED_REGISTRY_NUMBER), m_elementType(UNDEFINED_ELEMENT_TYPE), m_vtableinitialized(false)
+  SymbolClass::SymbolClass(const Token& id, UTI utype, NodeBlockClass * classblock, SymbolClassNameTemplate * parent, CompilerState& state) : Symbol(id, utype, state), m_resolver(NULL), m_classBlock(classblock), m_parentTemplate(parent), m_quarkunion(false), m_stub(true), m_stubcopy(false), m_stubForTemplate(false), m_stubForTemplateType(Nouti), m_stubForTemplateTypeIncomplete(false), m_stubcopyOf(Nouti), /*m_defaultValue(NULL),*/ m_isreadyDefaultValue(false) /* default */, m_bitsPacked(false), m_registryNumber(UNINITTED_REGISTRY_NUMBER), m_elementType(UNDEFINED_ELEMENT_TYPE), m_vtableinitialized(false)
   {
     appendBaseClass(Nouti, true);
   }
-  SymbolClass::SymbolClass(const SymbolClass& sref) : Symbol(sref), m_resolver(NULL), m_parentTemplate(sref.m_parentTemplate), m_quarkunion(sref.m_quarkunion), m_stub(sref.m_stub), m_stubcopy(sref.m_stubcopy), m_stubForTemplate(false), m_stubForTemplateType(Nouti), m_stubcopyOf(sref.m_stubcopyOf), /*m_defaultValue(NULL),*/ m_isreadyDefaultValue(false), m_bitsPacked(false), m_registryNumber(UNINITTED_REGISTRY_NUMBER), m_elementType(UNDEFINED_ELEMENT_TYPE), m_vtableinitialized(false)
+  SymbolClass::SymbolClass(const SymbolClass& sref) : Symbol(sref), m_resolver(NULL), m_parentTemplate(sref.m_parentTemplate), m_quarkunion(sref.m_quarkunion), m_stub(sref.m_stub), m_stubcopy(sref.m_stubcopy), m_stubForTemplate(false), m_stubForTemplateType(Nouti), m_stubForTemplateTypeIncomplete(false), m_stubcopyOf(sref.m_stubcopyOf), /*m_defaultValue(NULL),*/ m_isreadyDefaultValue(false), m_bitsPacked(false), m_registryNumber(UNINITTED_REGISTRY_NUMBER), m_elementType(UNDEFINED_ELEMENT_TYPE), m_vtableinitialized(false)
   {
     resetUlamType(m_state.getCompileThisIdx()); //symbols Hzy by default
 
@@ -138,6 +138,16 @@ namespace MFM {
   {
     m_stubForTemplateType = ttype;
     setStubForTemplate();
+  }
+
+  bool SymbolClass::isStubForTemplateTypeIncomplete()
+  {
+    return m_stubForTemplateTypeIncomplete;
+  }
+
+  void SymbolClass::setStubForTemplateTypeIncomplete(bool incomplete)
+  {
+    m_stubForTemplateTypeIncomplete = incomplete;
   }
 
   u32 SymbolClass::getBaseClassCount()
@@ -957,7 +967,7 @@ namespace MFM {
 
     m_state.pushClassContext(suti, cblock, cblock, false, NULL);
 
-    cblock->setDataMembersParseTree(suti, fromclassblock);
+    cblock->resetDataMembersParseTree(suti, fromclassblock);
     cblock->updateLineage(0);
     cblock->setDataMembersSymbolTable(suti, fromclassblock);
 


### PR DESCRIPTION
…fter parsing the template

This is a possible partial fix for parsing recursive typedefs.

`develop` version (https://github.com/DaveAckley/ULAM/commit/6e9cf8870b70f12a71e3df7d901ad7f88d453171) fails to compile this example (I tried copying this approach to bonds from [t41361](https://github.com/DaveAckley/ULAM/blob/develop/src/test/generic/safe/t41361_test_compiler_elementinheritedquarks_multibase_implicitselfpurevirtualfunccall_issue.test)):
```
quark TBond(Bool cSIDE) {
  typedef TBond(!cSIDE) Mate;

  Int mValue = 1;

  Int getValue() {
    return mValue;
  }
}

element A : TBond(true) {}
```
```
$ ../../ULAM/bin/culam -o .gen -i ../../ULAM/share/ulam/stdlib -i ../../ULAM/share/ulam/core A.ulam
OUTPUT DIRECTORY: .gen
./A.ulam:7:12: ERROR: Variable 'mValue' is not defined, or was used before declared in a function.
Unrecoverable Program Type Label FAILURE.
```
A stub class instance for `TBond(!cSIDE)` is created while parsing `TBond` template, but `mValue` is not yet added to template node's symbol table and this point, so the stub doesn't know about it. There's no check for this in `SymbolClassNameTemplate::makeAStubClassInstance`, it only checks if the template type is unseen.
The error happens when `TBond(true).Mate` is later fully instantiated in `Compiler::resolvingLoop`.

The fix allows ULAM to compile the snippet above and doesn't break any tests.

However I still have issues with my actual use case that are likely related. The idea was to create binary trees where each node has left and right "outgoing" bonds for children and an "incoming" bond for parent, which can be either left or right. Here's a version of this working as intended: [A.ulam.working.txt](https://github.com/DaveAckley/ULAM/files/10888847/A.ulam.working.txt). The other one compiles but produces wrong results in runtime, where `TBond(...).createBond` is unable to recognize the other atom as it's `Mate`: [A.ulam.broken.txt](https://github.com/DaveAckley/ULAM/files/10888853/A.ulam.broken.txt). The only difference is that typedefs for `LeftTree/RightTree` and `LeftBond/RightBond` are moved out of `TTree` template in working example (so `TTree` template is unseen when stubs are created?).

This is a more complicated case to debug, so I'm creating this draft for now, hope it helps.
