### PR TITLE
parser fix: allow local variable name to match other class method name

### DIFF
--- a/src/test/generic/safe/t41645_test_compiler_localvariablenamematchingotherclassmemberfunction.test
+++ b/src/test/generic/safe/t41645_test_compiler_localvariablenamematchingotherclassmemberfunction.test
@@ -1,0 +1,52 @@
+## -*- mode:ulam -*-
+#=t41644_test_compiler_localvariablenamematchingotherclassmemberfunction
+##
+##  gen output:
+##  "ok"
+##
+#!
+Exit status: 0
+Ue_A { Int test() {  QUser user;  user ( )printStatus . 0 cast return } }
+Uq_QUser : System { QTool tool();  :System<> <NOMAIN> }
+Uq_System { <NOMAIN> }
+Uq_QTool { <NOMAIN> }
+##
+##
+##
+#>A.ulam
+  ulam 5;
+element A {
+  Int test() {
+    QUser user;
+    user.printStatus();
+    return 0;
+  }
+}
+
+#:QUser.ulam
+  ulam 5;
+quark QUser : System {
+  QTool tool;
+
+  Void printStatus() {
+    Bool isOk = tool.isOk(); // local variable name can match method name
+    print(isOk ? "ok" : "error");
+  }
+}
+
+#:QTool.ulam
+  ulam 5;
+quark QTool {
+  Bool isOk() {
+    return true;
+  }
+}
+
+#:System.ulam
+ulam 1;
+quark System {
+Void print(String arg) native;
+Void print(Unsigned arg) native;
+}
+
+#.

--- a/src/test/generic/safe/t41652_test_compiler_localvariablenamematchingotherclassmemberfunction.test
+++ b/src/test/generic/safe/t41652_test_compiler_localvariablenamematchingotherclassmemberfunction.test
@@ -1,5 +1,5 @@
 ## -*- mode:ulam -*-
-#=t41644_test_compiler_localvariablenamematchingotherclassmemberfunction
+#=t41652_test_compiler_localvariablenamematchingotherclassmemberfunction
 ##
 ##  gen output:
 ##  "ok"
@@ -46,7 +46,6 @@ quark QTool {
 ulam 1;
 quark System {
 Void print(String arg) native;
-Void print(Unsigned arg) native;
 }
 
 #.

--- a/src/ulam/Parser.cpp
+++ b/src/ulam/Parser.cpp
@@ -4032,7 +4032,8 @@ namespace MFM {
   Node * Parser::parseFunctionCall(const Token& identTok)
   {
     Symbol * asymptr = NULL;
-    NodeBlock * currBlock = m_state.getCurrentBlock();
+    // local variable should not shadow a method in other class (t41645)
+    NodeBlock * currBlock = m_state.getCurrentMemberClassBlock();
 
     //cannot call a function if a local variable name shadows it
     if(currBlock && currBlock->isIdInScope(identTok.m_dataindex,asymptr))
@@ -4062,6 +4063,7 @@ namespace MFM {
     rtnNode->setNodeLocation(identTok.m_locator);
 
     //member selection doesn't apply to arguments (during parsing too)
+    currBlock = m_state.getCurrentBlock();
     m_state.pushCurrentBlockAndDontUseMemberBlock(currBlock);
 
     SYMBOLTYPEFLAG saveTheFlag = m_state.m_parsingVariableSymbolTypeFlag;

--- a/src/ulam/Parser.cpp
+++ b/src/ulam/Parser.cpp
@@ -4032,7 +4032,7 @@ namespace MFM {
   Node * Parser::parseFunctionCall(const Token& identTok)
   {
     Symbol * asymptr = NULL;
-    // local variable should not shadow a method in other class (t41645)
+    // local variable should not shadow a method in other class (t41652)
     NodeBlock * currBlock = m_state.getCurrentMemberClassBlock();
 
     //cannot call a function if a local variable name shadows it


### PR DESCRIPTION
A fix and a test for the following issue.

Local variable shadows member function of other class (`develop`, https://github.com/DaveAckley/ULAM/commit/6e9cf8870b70f12a71e3df7d901ad7f88d453171):
```
quark QTool {
  Bool isOk() {
    return true;
  }
}

quark QUser {
  Void printStatus() {
    QTool tool;
    Bool isOk = tool.isOk();

    DebugUtils du;
    du.print(isOk ? "ok" : "error");
  }
}
```
```
$ ../../ULAM/bin/ulam --ulamcompile QUser.ulam 
 Compile QUser.ulam, Res.ulam, Wall.ulam, Ulam5StdlibControl.ulam, DReg.ulam: ERROR: Close failed: 4096
./QUser.ulam:10:22: ERROR: 'isOk' cannot be a function because it is already declared as a variable of type Bool at: ..
./QUser.ulam:10:10: ERROR: .. this location.
./QUser.ulam:10:10: ERROR: Initial value of 'isOk' is missing.
./QUser.ulam:10:27: ERROR: Invalid Statement (possible missing semicolon).
Unrecoverable Program Parse FAILURE: <QUser.ulam>
Unrecoverable Program Parse FAILURE: <Res.ulam>
Unrecoverable Program Parse FAILURE: <Ulam5StdlibControl.ulam>
Unrecoverable Program Parse FAILURE: <Wall.ulam>


Error: 1 ulam build problem(s) detected
```